### PR TITLE
Readd disappeared entries in requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,7 @@
+bashate==0.6.0
 black==19.10b0
 flake8==3.7.9
-mypy==0.700
+mypy==0.761
 pylint==2.4.4
 pyinstaller==3.5
+yamllint==1.20.0


### PR DESCRIPTION
Apparently introduced in https://github.com/rhasspy/rhasspy-microphone-cli-hermes/commit/a15688a6061359e8edc8ea3b1b00a56758686767#diff-9746485032a333bedc47e790ce5228d8